### PR TITLE
Python package to retrieve and parse financial data from SEC EDGAR

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Arun Mittal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,197 @@
-# sec_api
-This package is to fetch company' financial data from SEC and return in json format.
+# sec-financial-data
+
+[![PyPI version](https://badge.fury.io/py/sec-financial-data.svg)](https://badge.fury.io/py/sec-financial-data)
+
+This Python package, sec-financial-data, is designed to simplify the process of retrieving and accessing publicly available financial data from the U.S. Securities and Exchange Commission's (SEC) EDGAR database. It acts as a convenient wrapper around the SEC's EDGAR APIs, providing a more Pythonic and user-friendly interface for developers and financial analysts.
+
+Core Purpose:
+
+The primary goal of the package is to enable users to programmatically fetch various types of financial information for publicly traded companies. This includes:
+
+    1. Company identification data (CIK numbers).
+    2. Raw XBRL (eXtensible Business Reporting Language) data, which forms the basis of SEC filings.
+    3. Formatted financial statements like Income Statements, Balance Sheets, and Cash Flow Statements.
+    4. Aggregated financial data points across multiple companies for comparative analysis.
+
+Key Features & Functionality:
+
+    1. User-Agent Management: The package emphasizes responsible API usage by allowing and encouraging users to set a custom User-Agent string, which is a requirement by the SEC for programmatic access.
+    2. Rate Limiting: It incorporates a basic rate-limiting mechanism to ensure that requests to the SEC EDGAR APIs do not exceed the allowed limit (10 requests per second), preventing potential IP blocks.
+    3. CIK Lookup:
+        1. Provides a function (get_cik_for_symbol) to retrieve a company's Central Index Key (CIK) using its stock ticker symbol.
+        2. The CIK map is fetched from the SEC and cached (@lru_cache) to improve performance for subsequent lookups.
+    4. Access to Raw XBRL Data:
+        1. get_company_all_facts(): Fetches the complete set of XBRL data (company facts) for a given CIK or ticker symbol. This is a comprehensive JSON object containing all reported financial concepts and their values over time.
+        2. get_company_specific_concept(): Allows users to retrieve data for a specific XBRL concept (e.g., "Revenues," "Assets") within a particular taxonomy (e.g., "us-gaap") for a company.
+    5. Aggregated Data (Frames API):
+        1. get_aggregated_frames_data(): Interacts with the SEC's "frames" API to fetch aggregated data for a specific XBRL tag, unit, and period (year/quarter) across all reporting entities. This is useful for market-wide analysis or peer comparisons.
+    6. Formatted Financial Statements:
+        1. The core of its value proposition for many users lies in the get_financial_statement() function and its specific wrappers: get_income_statement(), get_balance_sheet(), and get_cash_flow_statement().
+        2. These functions take raw XBRL data (obtained via get_company_facts()) and attempt to parse and structure it into a more conventional and readable JSON format for standard financial statements.
+        3. Data Normalization Logic:
+            1. It identifies relevant XBRL tags for common line items in each statement type (e.g., "Revenues", "NetIncomeLoss", "Assets", "CashAndCashEquivalentsAtCarryingValue").
+            2. It includes a list of primary and alternate XBRL tags for many financial line items, acknowledging that companies might use different tags for similar concepts. The _get_financial_value() helper method is crucial here, trying a primary tag first and then falling back to alternates.
+            3. It processes facts from 10-K (annual) and 10-Q (quarterly) filings.
+            4. It identifies the "canonical" report for each period (latest filing for a given end date) to avoid using superseded data.
+            5. It sorts reports chronologically and allows users to specify a limit for the number of recent periods.
+            6. It performs some derivations (e.g., calculating Gross Profit if not directly reported, deriving EBITDA, Net Debt).
+    7. SECHelper Class: This class serves as the main public interface for the package, encapsulating all the user-facing methods for easy access.
+
+How it Works (High-Level):
+
+    1. The user initializes the SECHelper class, optionally providing a `user_agent_string`.
+    2. When a method is called (e.g., get_income_statement("AAPL")):
+        1. If a ticker symbol is provided, it's first converted to a CIK.
+        2. The necessary SEC API endpoint is constructed.
+        3. A rate-limited HTTP GET request is made to the SEC API using the requests library.
+        4. The JSON response from the API is retrieved.
+        5. For financial statement functions, the extensive get_company_facts() data is processed:
+            1. Facts are filtered and grouped by filing (10-K/10-Q) and period.
+            2. The most recent, relevant filings are selected.
+            3. Values for predefined financial statement line items are extracted using the primary/alternate tag logic.
+            4. Some line items are calculated based on others.
+        6. The final data is returned as a Python dictionary or list of dictionaries.
+
+Target Audience:
+
+    1. Developers: Building financial applications, tools, or dashboards.
+    2. Financial Analysts & Researchers: Performing quantitative analysis, company valuation, or market research.
+    3. Students & Hobbyists: Learning about financial data and programming.
+
+Key Abstractions:
+
+    1. It abstracts away the complexities of directly interacting with the SEC EDGAR APIs (endpoint URLs, rate limits, raw XBRL structure).
+    2. It attempts to normalize the varied XBRL tags into a more standardized set of financial line items, though this is inherently challenging due to the flexibility of XBRL.
+
+Important Considerations for Users:
+
+    1. XBRL Tag Variability: Financial data reporting using XBRL can vary between companies and over time. While the package uses a list of common and alternate tags, it might not capture every possible variation for every company. Users might need to inspect the raw company_facts for specific or less common tags.
+    2. Data Accuracy: The package relies on the data as reported to the SEC. The parsing and normalization logic aims for accuracy but is based on common US GAAP interpretations.
+    3. API Changes: The SEC may update its APIs, which could potentially require updates to the package.
+    4. User-Agent: It's crucial to provide a descriptive user_agent for responsible API usage.
+
+In summary, sec-financial-data provides a valuable toolkit for accessing and working with SEC financial data in Python, significantly lowering the barrier to entry for retrieving and making sense of this rich dataset. It balances ease of use for common financial statements with the ability to access raw, detailed XBRL data for more advanced use cases.
+
+## Features
+
+*   Fetch financial statements (10-K, 10-Q) for a given company.
+*   Extract specific financial data points.
+*   User-friendly API.
+
+## Installation
+
+You can install `sec-financial-data` from PyPI:
+
+```bash
+pip install sec-financial-data
+```
+
+Requires Python 3.7+.
+
+## Usage
+```python
+from sec_financial_data.sec_financial_data import SECHelper
+import json
+
+# It's highly recommended to provide a descriptive user-agent.
+# Replace "YourAppName/1.0" and "your-email@example.com" accordingly.
+helper = SECHelper(user_agent_string="MyApp/1.0 (contact@example.com)")
+
+# --- Get CIK for a Ticker Symbol ---
+symbol = "AAPL"
+cik = helper.get_cik_for_symbol(symbol)
+if cik:
+    print(f"CIK for {symbol}: {cik}")
+else:
+    print(f"Could not find CIK for {symbol}.")
+
+# --- Get All Company Facts (XBRL data) ---
+# Can use symbol or CIK
+company_facts = helper.get_company_all_facts(symbol) # or helper.get_company_all_facts(cik)
+if company_facts:
+    # This is a large JSON object containing all reported XBRL data for the company.
+    # print(json.dumps(company_facts, indent=2)) # Be cautious, can be very large
+    print(f"Successfully fetched all facts for {company_facts.get('entityName', symbol)}.")
+    # Example: Accessing a specific fact (e.g., Assets for us-gaap)
+    # assets_data = company_facts.get('facts', {}).get('us-gaap', {}).get('Assets', {})
+    # if assets_data:
+    #     print(f"Assets data available: {assets_data.get('label')}")
+
+# --- Get Specific Company Concept ---
+taxonomy = "us-gaap"
+tag = "Revenues"
+concept_data = helper.get_company_specific_concept(symbol, taxonomy, tag) # or CIK
+if concept_data:
+    print(f"\nData for concept '{tag}' ({taxonomy}) for {symbol}:")
+    # print(json.dumps(concept_data, indent=2)) # Raw XBRL concept data
+    if 'units' in concept_data and 'USD' in concept_data['units']:
+        print(f"Label: {concept_data.get('label')}, Description: {concept_data.get('description')}")
+        print("Last 2 reported USD values for Revenues:")
+        for fact in concept_data['units']['USD'][-2:]: # Print last 2 facts
+            print(f"  Value: {fact.get('val')}, End Date: {fact.get('end')}, Form: {fact.get('form')}")
+
+# --- Get Aggregated Frames Data ---
+# Fetches data for a specific tag across many companies for a given period.
+# Example: Total Assets for all filers in Q1 2023.
+frame_taxonomy = "us-gaap"
+frame_tag = "Assets"
+frame_unit = "USD"
+frame_year = 2023
+frame_quarter = 1 # Optional, for quarterly data
+frame_instantaneous = True # True for balance sheet items
+
+assets_frame_data = helper.get_aggregated_frames_data(
+    frame_taxonomy, frame_tag, frame_unit, frame_year,
+    quarter=frame_quarter, instantaneous=frame_instantaneous
+)
+if assets_frame_data and 'data' in assets_frame_data:
+    print(f"\nAggregated '{frame_tag}' data for {frame_year} Q{frame_quarter}:")
+    print(f"Total companies reporting: {len(assets_frame_data['data'])}")
+    # print(json.dumps(assets_frame_data['data'][:2], indent=2)) # Print data for first 2 companies
+else:
+    print(f"No aggregated '{frame_tag}' data found for {frame_year} Q{frame_quarter}.")
+
+# --- Get Formatted Financial Statements ---
+
+# Get the last 3 Income Statements (combining 10-K and 10-Q, most recent first)
+income_all = helper.get_income_statement(symbol, limit=3)
+print(f"--- Income Statements (ALL, limit 3) for {symbol} ---")
+# print(json.dumps(income_all, indent=2))
+
+# Get the last 2 annual (10-K) Income Statements
+income_10k = helper.get_income_statement(symbol, limit=2, report_type="10-K")
+print(f"\n--- Income Statements (10-K, limit 2) for {symbol} ---")
+# print(json.dumps(income_10k, indent=2))
+if income_10k:
+    for report in income_10k:
+        print(f"Date: {report['date']}, Form: {report['_formType_original']}, Revenue: {report['revenue']}")
+
+# Get the last 4 quarterly (10-Q) Balance Sheets
+balance_sheet_10q = helper.get_balance_sheet(symbol, limit=4, report_type="10-Q")
+print(f"\n--- Balance Sheets (10-Q, limit 4) for {symbol} ---")
+# print(json.dumps(balance_sheet_10q, indent=2))
+if balance_sheet_10q:
+    for report in balance_sheet_10q:
+        print(f"Date: {report['date']}, Form: {report['_formType_original']}, Total Assets: {report['totalAssets']}")
+
+# Get Cash Flow Statement (last 2 periods)
+cash_flow_statement = helper.get_cash_flow_statement(symbol, limit=2)
+print(f"\nCash Flow Statement for {symbol} (last {len(cash_flow_statement)} periods):")
+# print(json.dumps(cash_flow_statement, indent=2))
+```
+
+*(Please replace the example above with a concise, working example of how to use your library.)*
+
+## Dependencies
+
+*   requests (>=2.20.0)
+
+## Contributing
+Contributions are welcome! Please see the Bug Tracker for issues or to submit a pull request.
+
+## License
+This project is licensed under the MIT License - see the LICENSE file for details.
+
+## Project Links
+*   Homepage
+*   Bug Tracker

--- a/main.py
+++ b/main.py
@@ -1,0 +1,135 @@
+# filename: main.py (or any script in your project)
+
+from sec_financial_data.sec_financial_data import SECHelper
+import json
+
+def main():
+    # Initialize the helper. It's highly recommended to provide a descriptive user-agent.
+    # Replace "YourAppName/1.0" with your application name and "your-email@example.com"
+    # with a contact email for responsible usage as per SEC guidelines.
+    helper = SECHelper(user_agent_string="sec_api/0.1.0 (arun.mittal.sjsu@gmail.com)")
+
+    symbol = "AAPL" # Example: Apple Inc.
+
+    print(f"\n--- Getting CIK for {symbol} ---")
+    cik = helper.get_cik_for_symbol(symbol)
+    if cik:
+        print(f"CIK for {symbol}: {cik}")
+    else:
+        print(f"Could not find CIK for {symbol}")
+        return # Exit if CIK not found
+
+    # --- Income Statement Examples ---
+    print(f"\n--- Getting Income Statement for {symbol} (ALL, limit 2) ---")
+    income_statement_all = helper.get_income_statement(symbol, limit=2, report_type="ALL")
+    if income_statement_all:
+        print(f"Found {len(income_statement_all)} reports.")
+        print(json.dumps(income_statement_all, indent=2))
+    else:
+        print(f"No income statement data found for {symbol}")
+
+    print(f"\n--- Getting Income Statement for {symbol} (10-K, limit 2) ---")
+    income_statement_10k = helper.get_income_statement(symbol, limit=2, report_type="10-K")
+    if income_statement_10k:
+        print(f"Found {len(income_statement_10k)} 10-K reports.")
+        print(json.dumps(income_statement_10k, indent=2))
+    else:
+        print(f"No 10-K income statement data found for {symbol}")
+
+    print(f"\n--- Getting Income Statement for {symbol} (10-Q, limit 2) ---")
+    income_statement_10q = helper.get_income_statement(symbol, limit=2, report_type="10-Q")
+    if income_statement_10q:
+        print(f"Found {len(income_statement_10q)} 10-Q reports.")
+        print(json.dumps(income_statement_10q, indent=2))
+    else:
+        print(f"No 10-Q income statement data found for {symbol}")
+
+    # --- Balance Sheet Examples ---
+    print(f"\n--- Getting Balance Sheet for {symbol} (ALL, limit 2) ---")
+    balance_sheet_all = helper.get_balance_sheet(symbol, limit=2, report_type="ALL")
+    if balance_sheet_all:
+        print(f"Found {len(balance_sheet_all)} reports.")
+        print(json.dumps(balance_sheet_all, indent=2))
+    else:
+        print(f"No balance sheet data found for {symbol}")
+
+    print(f"\n--- Getting Balance Sheet for {symbol} (10-K, limit 2) ---")
+    balance_sheet_10k = helper.get_balance_sheet(symbol, limit=2, report_type="10-K")
+    if balance_sheet_10k:
+        print(f"Found {len(balance_sheet_10k)} 10-K reports.")
+        print(json.dumps(balance_sheet_10k, indent=2))
+    else:
+        print(f"No 10-K balance sheet data found for {symbol}")
+
+    print(f"\n--- Getting Balance Sheet for {symbol} (10-Q, limit 2) ---")
+    balance_sheet_10q = helper.get_balance_sheet(symbol, limit=2, report_type="10-Q")
+    if balance_sheet_10q:
+        print(f"Found {len(balance_sheet_10q)} 10-Q reports.")
+        print(json.dumps(balance_sheet_10q, indent=2))
+    else:
+        print(f"No 10-Q balance sheet data found for {symbol}")
+
+    # --- Cash Flow Statement Examples ---
+    print(f"\n--- Getting Cash Flow Statement for {symbol} (ALL, limit 2) ---")
+    cash_flow_all = helper.get_cash_flow_statement(symbol, limit=2, report_type="ALL")
+    if cash_flow_all:
+        print(f"Found {len(cash_flow_all)} reports.")
+        print(json.dumps(cash_flow_all, indent=2))
+    else:
+        print(f"No cash flow statement data found for {symbol}")
+
+    # --- Advanced Usage: Fetching specific XBRL concepts ---
+    print(f"\n--- Getting specific concept: 'Revenues' for {symbol} ---")
+    revenues_concept = helper.get_company_specific_concept(symbol, "us-gaap", "Revenues")
+    if revenues_concept:
+        # This will contain raw XBRL facts. You'd typically process this further.
+        # For demonstration, we'll just print a small part of it.
+        print(f"Concept: {revenues_concept.get('label')}")
+        print(f"Description: {revenues_concept.get('description')}")
+
+        # Example of accessing some facts (first 2 for brevity)
+        if 'units' in revenues_concept and 'USD' in revenues_concept['units']:
+            print("First 2 USD facts for Revenues:")
+            for fact in revenues_concept['units']['USD'][:2]:
+                print(f"  Value: {fact.get('val')}, Fiscal Year: {fact.get('fy')}, Period: {fact.get('fp')}, End Date: {fact.get('end')}")
+        else:
+            print("No USD facts found for Revenues.")
+    else:
+        print(f"No concept data found for 'Revenues' for {symbol}")
+
+    # --- Advanced Usage: Getting aggregated frame data (e.g., Assets for all companies in a specific quarter) ---
+    print("\n--- Getting aggregated 'Assets' for Q1 2024 (USD) ---")
+    # This might return a very large dataset as it covers many companies.
+    # Be mindful of the output size and SEC rate limits.
+    # We'll only print a small sample for demonstration.
+    # Note: The SEC Frames API data availability can vary. Using a slightly older year for better chance of data.
+    year_for_frames = 2023
+    assets_q1_frames = helper.get_aggregated_frames_data(
+        "us-gaap", "Assets", "USD", year_for_frames, quarter=1, instantaneous=True
+    )
+    if assets_q1_frames and 'data' in assets_q1_frames: # The 'frames' API returns data under a 'data' key
+        print(f"Total number of companies reporting Assets in Q1 {year_for_frames}: {len(assets_q1_frames['data'])}")
+        if assets_q1_frames['data']:
+            print(f"Label for aggregated data: {assets_q1_frames.get('label', 'N/A')}")
+            print(f"Description for aggregated data: {assets_q1_frames.get('description', 'N/A')}")
+            print("Sample of Assets data (first 3 companies):")
+            for i, item in enumerate(assets_q1_frames['data'][:3]):
+                # The 'frames' API returns CIKs directly
+                sample_cik = item.get('cik')
+                sample_entity_name = item.get('entityName', 'N/A')
+                sample_value = item.get('val')
+                sample_accn = item.get('accn') # Accession number of the filing
+                sample_form = item.get('form') # Form type (e.g., 10-K, 10-Q)
+                sample_end = item.get('end')   # End date of the reported fact
+                print(
+                    f"  Company CIK: {sample_cik}, Name: {sample_entity_name}, "
+                    f"Value: {sample_value}, Form: {sample_form}, End Date: {sample_end}, Accn: {sample_accn}"
+                )
+        else:
+            print(f"No company data found within the aggregated Assets data for Q1 {year_for_frames}.")
+    else:
+        print(f"No aggregated Assets data found for Q1 {year_for_frames}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+# /Users/armittal/sec_api/pyproject.toml
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sec-financial-data" # Choose a unique name for PyPI
+version = "0.1.0"
+authors = [
+  { name="Arun Mittal", email="arun.mittal.sjsu@gmail.com" },
+]
+description = "A Python package to retrieve financial data from SEC EDGAR."
+readme = "README.md"
+requires-python = ">=3.7"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Financial and Insurance Industry",
+    "Topic :: Office/Business :: Financial",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    "requests>=2.20.0",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/armittal89/sec_api"
+"Bug Tracker" = "https://github.com/armittal89/sec_api/issues"
+
+[tool.setuptools]
+license-files = ["LICENSE"]

--- a/sec_financial_data/__init__.py
+++ b/sec_financial_data/__init__.py
@@ -1,0 +1,2 @@
+# Makes SECHelper directly available under the sec_financial_data package
+from .sec_financial_data import SECHelper

--- a/sec_financial_data/sec_financial_data.py
+++ b/sec_financial_data/sec_financial_data.py
@@ -1,0 +1,1071 @@
+# filename: sec_financial_data/sec_financial_data.py
+
+import requests
+import time
+from functools import lru_cache
+
+# Base URLs for SEC EDGAR APIs
+SEC_BASE_URL = "https://www.sec.gov"
+DATA_SEC_BASE_URL = "https://data.sec.gov"
+
+# Rate limiting: SEC allows up to 10 requests per second.
+# We'll implement a simple delay to ensure we don't exceed this.
+# A more robust solution for high-volume usage might involve a token bucket algorithm.
+LAST_REQUEST_TIME = 0
+REQUEST_INTERVAL = 0.11  # Approximately 9 requests per second to be safe
+
+def _rate_limit():
+    """
+    Ensures that API requests respect SEC's rate limits (max 10 requests per second).
+    Introduces a small delay if requests are being made too quickly.
+    """
+    global LAST_REQUEST_TIME
+    current_time = time.time()
+    elapsed = current_time - LAST_REQUEST_TIME
+    if elapsed < REQUEST_INTERVAL:
+        time.sleep(REQUEST_INTERVAL - elapsed)
+    LAST_REQUEST_TIME = time.time()
+
+@lru_cache(maxsize=1)
+def _fetch_and_cache_cik_map(headers_tuple):
+    """
+    Fetches and caches the company ticker to CIK mapping from SEC.gov.
+    The CIKs are padded with leading zeros to 10 digits as required by some SEC APIs.
+    This function is cached based on the headers_tuple to allow different User-Agents
+    to have potentially different cache entries if needed, though typically it's one map.
+
+    Returns:
+        dict: A dictionary where keys are uppercase ticker symbols and values
+              are 10-digit CIK strings. Returns an empty dict on error.
+    """
+    _rate_limit()
+    headers = dict(headers_tuple) # Convert back from tuple for requests
+    url = f"{SEC_BASE_URL}/files/company_tickers.json"
+    try:
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()  # Raise an HTTPError for bad responses (4xx or 5xx)
+        data = response.json()
+
+        # The JSON structure is a list of dictionaries like {"cik_str": 320193, "ticker": "AAPL", "title": "Apple Inc."}
+        # Create a dictionary mapping ticker to CIK (padded to 10 digits)
+        cik_map = {item['ticker'].upper(): str(item['cik_str']).zfill(10) for item in data.values()}
+        return cik_map
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching CIK map with User-Agent '{headers.get('User-Agent')}': {e}")
+        return {}
+
+def _get_cik_from_map(symbol, cik_map):
+    """
+    Retrieves the Central Index Key (CIK) for a given stock ticker symbol.
+
+    Args:
+        symbol (str): The stock ticker symbol (e.g., "AAPL").
+
+    Returns:
+        str: The 10-digit CIK as a string, or None if not found.
+    """
+    return cik_map.get(symbol.upper())
+
+def _get_company_facts_request(symbol_or_cik, headers, get_cik_func):
+    """
+    Fetches all company facts (XBRL disclosures) for a given company.
+    This provides a comprehensive dataset for a company, including various
+    financial concepts and their reported values over different periods.
+
+    Args:
+        symbol_or_cik (str): The stock ticker symbol (e.g., "AAPL") or
+                             the 10-digit CIK (e.g., "0000320193").
+        headers (dict): The HTTP headers to use for the request.
+        get_cik_func (callable): A function to resolve a symbol to a CIK.
+
+    Returns:
+        dict: A dictionary containing all company facts in JSON format,
+              or None if the data cannot be retrieved.
+    """
+    cik = symbol_or_cik
+    if not cik.isdigit() or len(cik) != 10:
+        cik = get_cik_func(symbol_or_cik) # Use the passed function
+        if not cik:
+            print(f"Error: Could not find CIK for symbol: {symbol_or_cik}")
+            return None
+
+    _rate_limit()
+    url = f"{DATA_SEC_BASE_URL}/api/xbrl/companyfacts/CIK{cik}.json"
+    try:
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching company facts for CIK {cik}: {e}")
+        return None
+
+def _get_company_concept_request(symbol_or_cik, taxonomy, tag, headers, get_cik_func):
+    """
+    Fetches specific XBRL concept data for a given company.
+    Examples of taxonomy: "us-gaap", "ifrs-full", "dei", "srt"
+    Examples of tag: "Revenues", "Assets", "NetIncomeLoss", "EarningsPerShareBasic"
+
+    Args:
+        symbol_or_cik (str): The stock ticker symbol (e.g., "AAPL") or
+                             the 10-digit CIK (e.g., "0000320193").
+        taxonomy (str): The XBRL taxonomy (e.g., "us-gaap").
+        tag (str): The XBRL tag/concept (e.g., "Revenues").
+        headers (dict): The HTTP headers to use for the request.
+        get_cik_func (callable): A function to resolve a symbol to a CIK.
+
+    Returns:
+        dict: A dictionary containing the concept data in JSON format,
+              or None if the data cannot be retrieved.
+    """
+    cik = symbol_or_cik
+    if not cik.isdigit() or len(cik) != 10:
+        cik = get_cik_func(symbol_or_cik) # Use the passed function
+        if not cik:
+            print(f"Error: Could not find CIK for symbol: {symbol_or_cik}")
+            return None
+
+    _rate_limit()
+    url = f"{DATA_SEC_BASE_URL}/api/xbrl/companyconcept/CIK{cik}/{taxonomy}/{tag}.json"
+    try:
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching concept '{tag}' for CIK {cik}: {e}")
+        return None
+
+def _get_frames_data_request(taxonomy, tag, unit, year, headers, quarter=None, instantaneous=False):
+    """
+    Fetches aggregated XBRL data across reporting entities for a specific concept
+    and calendrical period. This API aggregates one fact for each reporting entity
+    that is last filed that most closely fits the calendrical period requested.
+
+    Args:
+        taxonomy (str): The XBRL taxonomy (e.g., "us-gaap").
+        tag (str): The XBRL tag/concept (e.g., "Assets").
+        unit (str): The unit of measure (e.g., "USD", "shares").
+        year (int): The calendar year (e.g., 2023).
+        headers (dict): The HTTP headers to use for the request.
+        quarter (int, optional): The quarter (1, 2, 3, or 4). If None, fetches annual data.
+        instantaneous (bool, optional): True for instantaneous data (e.g., balance sheet items),
+                                        False for duration data (e.g., income statement items).
+                                        Defaults to False.
+
+    Returns:
+        dict: A dictionary containing the aggregated frame data in JSON format,
+              or None if the data cannot be retrieved.
+    """
+    period = f"CY{year}"
+    if quarter:
+        period += f"Q{quarter}"
+    if instantaneous:
+        period += "I" # Suffix 'I' for instantaneous periods
+
+    _rate_limit()
+    url = f"{DATA_SEC_BASE_URL}/api/xbrl/frames/{taxonomy}/{tag}/{unit}/{period}.json"
+    try:
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching frames data for {tag} in {period}: {e}")
+        return None
+
+def _get_financial_statement_data(symbol_or_cik, statement_type, limit, report_type, headers, get_cik_func, get_company_facts_func):
+    """
+    Fetches and formats basic financial statement data for a given symbol.
+    This function aims to provide a simplified, JSON structure for
+    common financial statements.
+
+    Args:
+        symbol (str): The stock ticker symbol (e.g., "AAPL").
+        statement_type (str): Type of statement ("income_statement",
+                                        "balance_sheet", "cash_flow").
+        limit (int): Number of most recent report periods to retrieve.
+        report_type (str): The type of report to filter by.
+                           Can be "10-K", "10-Q", or "ALL" (default).
+        headers (dict): HTTP headers for requests.
+        get_cik_func (callable): Function to get CIK.
+        get_company_facts_func (callable): Function to get company facts.
+
+    Returns:
+        list: A list of dictionaries, where each dictionary represents a period's
+              financial data. Returns an empty list if data cannot be retrieved or
+              statement type is invalid.
+    """
+    # Resolve CIK using the provided function
+    cik = symbol_or_cik if (isinstance(symbol_or_cik, str) and symbol_or_cik.isdigit() and len(symbol_or_cik) == 10) else get_cik_func(symbol_or_cik)
+    if not cik:
+        print(f"Error: Could not find CIK for: {symbol_or_cik}")
+        return []
+
+    def _get_financial_value(data_dict, primary_tag, alternate_tags=None, default=0):
+        """
+        Retrieves a financial value from a dictionary of financial data.
+
+        This helper function attempts to find a value associated with a `primary_tag`.
+        If the `primary_tag` is not found or its value is None, it will then try
+        any `alternate_tags` provided, in the order they are listed.
+        If no suitable tag yields a non-None value, the `default` value is returned.
+
+        Args:
+            data_dict (dict): The dictionary containing financial data, where keys are
+                              XBRL tags and values are the reported financial figures.
+            primary_tag (str): The preferred XBRL tag to look for.
+            alternate_tags (str or list, optional): A single XBRL tag string or a list of
+                                                   XBRL tag strings to try if the `primary_tag`
+                                                   is not found or its value is None. Defaults to None.
+            default (any, optional): The value to return if no tag provides a non-None value.
+                                     Defaults to 0.
+
+        Returns:
+            any: The financial value found, or the `default` value.
+        """
+        tags_to_try = [primary_tag]
+        if alternate_tags:
+            if isinstance(alternate_tags, str):
+                tags_to_try.append(alternate_tags)
+            elif isinstance(alternate_tags, list):
+                tags_to_try.extend(alternate_tags)
+
+        for tag in tags_to_try:
+            if tag in data_dict:
+                val = data_dict.get(tag)
+                if val is not None:
+                    return val
+        return default
+
+    company_facts = get_company_facts_func(cik) # Use the passed function
+    if not company_facts:
+        return []
+
+    # Define common US GAAP tags for each statement type
+    # This is a simplified list; real financial statements have many more tags.
+    # Users can extend this list based on their needs by exploring company_facts data.
+    statement_tags = {
+        "income_statement": [
+            "Revenues",
+            "RevenueFromContractWithCustomerExcludingAssessedTax",
+            "SalesRevenueNet",
+            "SalesRevenueGoodsNet",
+            "SalesRevenueServicesNet",
+            "CostOfRevenue",
+            "CostOfGoodsAndServicesSold", # Common alternative for CostOfRevenue
+            "GrossProfit",
+            "ResearchAndDevelopmentExpense",
+            "SellingGeneralAndAdministrativeExpense",
+            "GeneralAndAdministrativeExpense",
+            "SellingAndMarketingExpense",
+            "OtherOperatingExpenses",
+            "OperatingExpenses",
+            "OperatingIncomeLoss",
+            "InterestIncomeExpenseNet",
+            "InterestIncome",
+            "InterestExpense",
+            "NonoperatingIncomeLoss",
+            "IncomeLossFromContinuingOperationsBeforeIncomeTax",
+            "IncomeBeforeIncomeTax",
+            "IncomeBeforeTax",
+            "ProfitLossBeforeTax",
+            "IncomeTaxExpenseBenefit",
+            "NetIncomeLoss",
+            "NetIncomeLossFromDiscontinuedOperationsNetOfTax",
+            "EarningsPerShareBasic",
+            "EarningsPerShareDiluted",
+            "WeightedAverageNumberOfSharesOutstandingBasic",
+            "WeightedAverageNumberOfDilutedSharesOutstanding",
+            "DepreciationDepletionAndAmortization"
+        ],
+        "balance_sheet": [
+            "CashAndCashEquivalentsAtCarryingValue",
+            "MarketableSecuritiesCurrent", # For shortTermInvestments
+            "ShortTermInvestments", # Alternative for shortTermInvestments
+            "AccountsReceivableNetCurrent", # For netReceivables
+            "AccountsReceivableTradeCurrent", # For accountsReceivables (trade specific)
+            "OtherReceivablesCurrent", # For otherReceivables
+            "InventoryNet",
+            "PrepaidExpenseCurrent", # For prepaids
+            "OtherAssetsCurrent",
+            "AssetsCurrent", # For totalCurrentAssets
+            "PropertyPlantAndEquipmentNet",
+            "Goodwill",
+            "IntangibleAssetsNetExcludingGoodwill", # For intangibleAssets
+            "MarketableSecuritiesNoncurrent", # For longTermInvestments
+            "LongTermInvestments", # Alternative for longTermInvestments
+            "DeferredTaxAssetsNet", # For taxAssets (can be sum of current/noncurrent)
+            "OtherAssetsNoncurrent",
+            "AssetsNoncurrent", # For totalNonCurrentAssets
+            "Assets",
+            "Assets", # For totalAssets
+            "AccountsPayableCurrent", # For accountPayables
+            "LongTermDebtCurrent",
+            "OtherAccountsPayableCurrent", # For otherPayables
+            "AccruedLiabilitiesCurrent", # For accruedExpenses
+            "DebtCurrent", # Preferred total short-term debt
+            "CommercialPaper",
+            "LongTermDebtCurrentMaturities", # Specific for current portion of long-term debt
+            "NotesPayableCurrent",
+            "ShortTermBorrowings", # General short-term borrowings
+            "LongTermDebtCurrentMaturitiesAndOtherShortTermDebt", # Broader fallback for current LTD + other STD
+            "OperatingLeaseLiabilityCurrent", # For capitalLeaseObligationsCurrent (new standard)
+            "CapitalLeaseObligationsCurrent", # For capitalLeaseObligationsCurrent (old standard)
+            "IncomeTaxesPayable", # For taxPayables
+            "DeferredRevenueCurrent", # For deferredRevenue (current)
+            "ContractWithCustomerLiabilityCurrent", # Alt for deferredRevenue (current)
+            "OtherLiabilitiesCurrent",
+            "LiabilitiesCurrent", # For totalCurrentLiabilities
+            "LongTermDebtNoncurrent",
+            "OperatingLeaseLiabilityNoncurrent", # For capitalLeaseObligationsNonCurrent (new)
+            "CapitalLeaseObligationsNoncurrent", # For capitalLeaseObligationsNonCurrent (old)
+            "DeferredRevenueNoncurrent", # For deferredRevenue (non-current)
+            "ContractWithCustomerLiabilityNoncurrent", # Alt for deferredRevenue (non-current)
+            "DeferredTaxLiabilitiesNoncurrent", # Or DeferredTaxLiabilitiesNet
+            "OtherLiabilitiesNoncurrent",
+            "LiabilitiesNoncurrent",
+            "StockholdersEquity"
+            "Liabilities", # For totalLiabilities
+            "TreasuryStockValue",
+            "PreferredStockValue",
+            "RedeemablePreferredStockCarryingAmount", # Alt for preferredStock
+            "CommonStockValue",
+            "CommonStocksIncludingAdditionalPaidInCapital", # Alt if APIC is combined
+            "AdditionalPaidInCapital",
+            "RetainedEarningsAccumulatedDeficit",
+            "AccumulatedOtherComprehensiveIncomeLossNetOfTax",
+            "MinorityInterest", # For minorityInterest
+            "NoncontrollingInterest", # Alt for minorityInterest
+            "StockholdersEquity", # For totalStockholdersEquity
+            "StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest" # Alt for totalStockholdersEquity
+        ],
+        "cash_flow": [
+            # Operating Activities - Reconciliation & Direct
+            "NetIncomeLoss", # Needed for reconciliation if not directly reported in CF
+            "DepreciationDepletionAndAmortization",
+            "ShareBasedCompensation",
+            "DeferredIncomeTaxExpenseBenefit", # General tag for deferred income tax in CF
+            "IncreaseDecreaseInDeferredIncomeTaxes", # Alternative
+            "IncreaseDecreaseInAccountsReceivableNetCurrent", # For accountsReceivables flow
+            "IncreaseDecreaseInInventoriesNet", # For inventory flow
+            "IncreaseDecreaseInAccountsPayableCurrent", # For accountsPayables flow
+            "IncreaseDecreaseInOtherOperatingAssetsLiabilitiesNet", # For 'otherWorkingCapital'
+            "OtherNoncashIncomeExpense", # For 'otherNonCashItems'
+            "NetCashProvidedByUsedInOperatingActivities",
+
+            # Investing Activities
+            "PaymentsToAcquirePropertyPlantAndEquipment", # For 'investmentsInPropertyPlantAndEquipment' & 'capitalExpenditure'
+            "PaymentsToAcquireBusinessesNetOfCashAcquired", # For 'acquisitionsNet'
+            "PaymentsForPurchasesOfInvestments", # For 'purchasesOfInvestments'
+            "ProceedsFromSaleAndMaturityOfMarketableSecurities", # For 'salesMaturitiesOfInvestments'
+            "OtherInvestingActivitiesCashFlows", # For 'otherInvestingActivities'
+            "NetCashProvidedByUsedInInvestingActivities",
+
+            # Financing Activities
+            "ProceedsFromIssuanceOfLongTermDebt",
+            "RepaymentsOfLongTermDebt",
+            "ProceedsFromShortTermDebt",
+            "RepaymentsOfShortTermDebt",
+            "ProceedsFromIssuanceOfCommonStock",
+            "PaymentsForRepurchaseOfCommonStock", # For 'commonStockRepurchased'
+            "ProceedsFromIssuanceOfPreferredStock",
+            "PaymentsForRepurchaseOfPreferredStock",
+            "PaymentsOfDividendsCommonStock", # For 'commonDividendsPaid'
+            "PaymentsOfDividendsPreferredStock", # For 'preferredDividendsPaid'
+            "OtherFinancingActivitiesCashFlows", # For 'otherFinancingActivities'
+            "NetCashProvidedByUsedInFinancingActivities",
+
+            # Summary & Other
+            "CashAndCashEquivalentsPeriodIncreaseDecrease",
+            "EffectOfExchangeRateOnCashAndCashEquivalents",
+            "CashAndCashEquivalentsAtCarryingValue", # For 'cashAtEndOfPeriod' (also in BS tags)
+            "CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalentsAtBeginningOfPeriod", # For 'cashAtBeginningOfPeriod'
+            "CashAndCashEquivalentsAtBeginningOfPeriod", # Alternative for beginning cash
+            "IncomeTaxesPaidNet",
+            "InterestPaidNet",
+        ]
+    }
+
+    if statement_type not in statement_tags:
+        print(f"Error: Invalid financial statement type: {statement_type}. Choose from: {', '.join(statement_tags.keys())}")
+        return []
+
+    required_tags = statement_tags[statement_type]
+    
+    # Step 1: Collect data for each unique report instance (filing).
+    # Key: (form_group, end_date, filed_at)
+    # Value: Dictionary holding report details and its financial data.
+    # report_instances_data is already initialized before this loop.
+    report_instances_data = {}
+
+    facts_section = company_facts.get('facts', {})
+    us_gaap_facts = facts_section.get('us-gaap', {})
+
+    for tag in required_tags:
+        concept_data = us_gaap_facts.get(tag, {})
+        for unit_type, facts_list in concept_data.get('units', {}).items():
+            # We are interested in monetary units, typically USD.
+            # However, some concepts might be in other units (e.g., shares for EPS).
+            # For simplicity, we'll process all units and let the structure of company_facts guide us.
+            # If specific unit filtering is needed, it can be added here (e.g., if unit_type != "USD": continue)
+            for fact in facts_list:
+                fiscal_year = fact.get('fy')
+                fiscal_period = fact.get('fp')
+                form_type = fact.get('form')
+                filed_at = fact.get('filed')
+                value = fact.get('val')
+                end_date = fact.get('end')
+                start_date = fact.get('start') # This start_date is per-fact, might not be the period start_date
+
+                if not (form_type and filed_at and end_date and fiscal_year is not None and fiscal_period and value is not None):
+                    continue
+
+                form_group = None
+                if form_type.upper().startswith('10-K'):
+                    form_group = '10-K'
+                elif form_type.upper().startswith('10-Q'):
+                    form_group = '10-Q'
+                else:
+                    continue # Only process 10-K and 10-Q related forms
+
+                report_instance_key = (form_group, end_date, filed_at)
+
+                if report_instance_key not in report_instances_data:
+                    report_instances_data[report_instance_key] = {
+                        "symbol": symbol_or_cik.upper() if isinstance(symbol_or_cik, str) and not symbol_or_cik.isdigit() else "N/A_CIK_USED", # Store original symbol if provided
+                        "fiscalYear": fiscal_year,
+                        "fiscalPeriod": fiscal_period,
+                        "formType": form_type,
+                        "formGroup": form_group,
+                        "filedAt": filed_at,
+                        "endDate": end_date,
+                        # Use the start_date from the first fact encountered for this report instance.
+                        # This might need refinement if a true period start_date is required across all facts.
+                        "startDate": start_date,
+                        "data": {}
+                    }
+                report_instances_data[report_instance_key]['data'][tag] = value
+
+    # Step 2: Determine the canonical (latest filed) report for each (form_group, end_date)
+    canonical_reports = {}
+    for report_obj in report_instances_data.values():
+        key = (report_obj['formGroup'], report_obj['endDate'])
+        if key not in canonical_reports or report_obj['filedAt'] > canonical_reports[key]['filedAt']:
+            canonical_reports[key] = report_obj
+
+    all_canonical_reports_list = list(canonical_reports.values())
+
+    # Step 3: Separate into 10-K and 10-Q lists
+    ten_k_reports = [r for r in all_canonical_reports_list if r['formGroup'] == '10-K']
+    ten_q_reports = [r for r in all_canonical_reports_list if r['formGroup'] == '10-Q']
+
+    # Step 4: Sort each list by endDate (primary) and filedAt (secondary, for tie-breaking), most recent first
+    sort_key_func = lambda r: (r.get('endDate', '0000-00-00'), r.get('filedAt', '0000-00-00T00:00:00Z'))
+
+    ten_k_reports.sort(key=sort_key_func, reverse=True)
+    ten_q_reports.sort(key=sort_key_func, reverse=True)
+
+    # Step 5: Select reports based on report_type and apply limit
+    selected_reports = []
+    report_type_upper = report_type.upper()
+
+    if report_type_upper == "10-K":
+        selected_reports = ten_k_reports[:limit]
+    elif report_type_upper == "10-Q":
+        selected_reports = ten_q_reports[:limit]
+    elif report_type_upper == "ALL":
+        # Combine, sort, then limit
+        combined_reports = ten_k_reports + ten_q_reports
+        combined_reports.sort(key=sort_key_func, reverse=True) # Ensure overall chronological order
+        selected_reports = combined_reports[:limit]
+    else:
+        print(f"Warning: Invalid report_type '{report_type}'. Defaulting to 'ALL'.")
+        combined_reports = ten_k_reports + ten_q_reports
+        combined_reports.sort(key=sort_key_func, reverse=True)
+        selected_reports = combined_reports[:limit]
+
+    # Step 6 (was Step 7): Format results
+    formatted_results = []
+
+    for period_details in selected_reports:
+        data = period_details.get("data", {})
+
+        # Determine period string (FY, Q1, Q2, etc.)
+        period_val = period_details["fiscalPeriod"]
+        if period_details["formGroup"] == '10-K':
+            period_val = 'FY'
+
+        # Revenue: Try a list of common tags in order of preference.
+        # Ensure these tags are included in statement_tags["income_statement"] above.
+        revenue = 0 # Default value
+        revenue_possible_tags = [
+            'Revenues',
+            'RevenueFromContractWithCustomerExcludingAssessedTax',
+            'SalesRevenueNet',
+            'SalesRevenueGoodsNet',
+            'SalesRevenueServicesNet'
+        ]
+        for r_tag in revenue_possible_tags:
+            if r_tag in data: # Check if the tag was found and data collected for it
+                revenue = _get_financial_value(data, r_tag)
+                if revenue != 0: # If we found a non-zero revenue, prefer it. If it's 0, continue checking.
+                    break # Use the first non-zero revenue found from the preferred list
+        # If all found tags resulted in 0, revenue remains 0. If no tags were found, revenue remains 0.
+
+        costOfRevenue = 0
+        costOfRevenue_possible_tags = ['CostOfRevenue', 'CostOfGoodsAndServicesSold']
+        for tag in costOfRevenue_possible_tags:
+            if tag in data:
+                costOfRevenue = _get_financial_value(data, tag)
+                if costOfRevenue != 0:
+                    break
+
+        # GrossProfit can be explicitly found or calculated.
+        # If GrossProfit tag exists and is non-zero, use it. Otherwise, calculate.
+        grossProfit_explicit = _get_financial_value(data, 'GrossProfit')
+        grossProfit = grossProfit_explicit if grossProfit_explicit != 0 else (revenue - costOfRevenue)
+        # If GrossProfit was explicitly 0, but revenue and CoR allow calculation, it will be calculated.
+        # If GrossProfit tag was not found, it will be calculated.
+
+        generalAndAdministrativeExpenses = 0
+        sellingAndMarketingExpenses = 0
+        researchAndDevelopmentExpense = _get_financial_value(data, "ResearchAndDevelopmentExpense")
+        sga_combined = _get_financial_value(data, "SellingGeneralAndAdministrativeExpense")
+        ga_separate = _get_financial_value(data, "GeneralAndAdministrativeExpense")
+        sm_separate = _get_financial_value(data, "SellingAndMarketingExpense")
+        otherOperatingExpenses_val = _get_financial_value(data, "OtherOperatingExpenses")
+
+        if ga_separate != 0 or sm_separate != 0: # Prefer separate tags if available
+            generalAndAdministrativeExpenses = ga_separate
+            sellingAndMarketingExpenses = sm_separate
+        elif sga_combined != 0 : # Use combined SG&A
+            generalAndAdministrativeExpenses = sga_combined
+
+        otherExpenses_val = otherOperatingExpenses_val
+
+        # Calculate total operating expenses
+        # Use the specific 'OperatingExpenses' tag if available and non-zero, otherwise sum components.
+        operatingExpenses_from_tag = _get_financial_value(data, 'OperatingExpenses')
+        calculated_operating_components_sum = researchAndDevelopmentExpense + generalAndAdministrativeExpenses + sellingAndMarketingExpenses + otherExpenses_val
+
+        operatingExpenses = operatingExpenses_from_tag if operatingExpenses_from_tag != 0 else calculated_operating_components_sum # Use explicit if non-zero
+
+        costAndExpenses = costOfRevenue + operatingExpenses # Derived (Cost of Revenue + All Operating Expenses)
+
+        # Interest Income / Expense
+        # Prioritize discrete InterestIncome and InterestExpense. Fallback to InterestIncomeExpenseNet.
+        interestIncome_val = _get_financial_value(data, 'InterestIncome')
+        interestExpense_val = _get_financial_value(data, 'InterestExpense')
+        interestIncomeExpenseNet_val = _get_financial_value(data, 'InterestIncomeExpenseNet')
+
+        if interestIncome_val == 0 and interestExpense_val == 0 and interestIncomeExpenseNet_val != 0:
+            if interestIncomeExpenseNet_val > 0:
+                interestIncome_val = interestIncomeExpenseNet_val
+            else: # interestIncomeExpenseNet_val < 0
+                interestExpense_val = abs(interestIncomeExpenseNet_val)
+        # If gross values were present, they are used. If only net was present, it's now split.
+        # If all were zero, they remain zero.
+
+        netInterestIncome = interestIncome_val - interestExpense_val # Derived
+
+        depreciationAndAmortization = _get_financial_value(data, 'DepreciationDepletionAndAmortization')
+        
+        operatingIncome = _get_financial_value(data, 'OperatingIncomeLoss')
+        # If operatingIncome is zero from tag, try to derive it
+        if operatingIncome == 0 and grossProfit != 0 and (researchAndDevelopmentExpense !=0 or generalAndAdministrativeExpenses !=0 or sellingAndMarketingExpenses !=0 or otherExpenses_val !=0) :
+            operatingIncome = grossProfit - (researchAndDevelopmentExpense + generalAndAdministrativeExpenses + sellingAndMarketingExpenses + otherExpenses_val + depreciationAndAmortization) # More complete OpEx for derivation
+
+        ebitda = operatingIncome + depreciationAndAmortization # Derived
+        ebit = operatingIncome # ebit is Operating Income
+
+        totalOtherIncomeExpensesNet = _get_financial_value(data, 'NonoperatingIncomeLoss')
+
+        incomeBeforeTax = 0
+        incomeBeforeTax_possible_tags = [
+            'IncomeLossFromContinuingOperationsBeforeIncomeTax',
+            'IncomeBeforeIncomeTax',
+            'IncomeBeforeTax',
+            'ProfitLossBeforeTax'
+        ]
+        for tag in incomeBeforeTax_possible_tags:
+            if tag in data:
+                incomeBeforeTax = _get_financial_value(data, tag)
+                if incomeBeforeTax != 0: break
+        # Fallback calculation for Income Before Tax (EBT)
+        if incomeBeforeTax == 0 and operatingIncome != 0:
+             incomeBeforeTax = operatingIncome + netInterestIncome + totalOtherIncomeExpensesNet # Common derivation
+
+        incomeTaxExpense = _get_financial_value(data, 'IncomeTaxExpenseBenefit')
+
+        netIncome = _get_financial_value(data, 'NetIncomeLoss')
+        netIncomeFromDiscontinuedOperations = _get_financial_value(data, 'NetIncomeLossFromDiscontinuedOperationsNetOfTax')
+        netIncomeFromContinuingOperations = netIncome - netIncomeFromDiscontinuedOperations # Derived
+
+        eps = _get_financial_value(data, 'EarningsPerShareBasic')
+        epsDiluted = _get_financial_value(data, 'EarningsPerShareDiluted')
+        weightedAverageShsOut = _get_financial_value(data, 'WeightedAverageNumberOfSharesOutstandingBasic')
+        weightedAverageShsOutDil = _get_financial_value(data, 'WeightedAverageNumberOfDilutedSharesOutstanding')
+
+        # Base item structure common to all statement types
+        base_item = {
+            "date": period_details["endDate"],
+            "symbol": symbol_or_cik.upper() if isinstance(symbol_or_cik, str) and not symbol_or_cik.isdigit() else "N/A_CIK_USED", # Store original symbol if provided
+            "reportedCurrency": "USD", # Assuming USD
+            "cik": cik,
+            "filingDate": period_details["filedAt"][:10],
+            "acceptedDate": period_details["filedAt"],
+            "fiscalYear": str(period_details["fiscalYear"]),
+            "period": period_val,
+            "fiscalDateEnding": period_details["endDate"],
+            "_formType_original": period_details["formType"], # Internal reference
+        }
+
+        if statement_type == "income_statement":
+            item = {
+                **base_item,
+                "revenue": revenue,
+                "costOfRevenue": costOfRevenue,
+                "grossProfit": grossProfit,
+                "researchAndDevelopmentExpense": researchAndDevelopmentExpense,
+                "generalAndAdministrativeExpenses": generalAndAdministrativeExpenses,
+                "sellingAndMarketingExpenses": sellingAndMarketingExpenses,
+                "otherExpenses": otherExpenses_val,
+                "operatingExpenses": operatingExpenses,
+                "costAndExpenses": costAndExpenses,
+                "interestIncome": interestIncome_val,
+                "interestExpense": interestExpense_val,
+                "depreciationAndAmortization": depreciationAndAmortization,
+                "ebitda": ebitda,
+                "operatingIncome": operatingIncome,
+                "totalOtherIncomeExpensesNet": totalOtherIncomeExpensesNet,
+                "incomeBeforeTax": incomeBeforeTax,
+                "incomeTaxExpense": incomeTaxExpense,
+                "netIncome": netIncome,
+                "eps": eps,
+                "epsDiluted": epsDiluted,
+                "weightedAverageShsOut": weightedAverageShsOut,
+                "weightedAverageShsOutDil": weightedAverageShsOutDil,
+                "ebit": ebit,
+                "netIncomeFromContinuingOperations": netIncomeFromContinuingOperations,
+                "netIncomeFromDiscontinuedOperations": netIncomeFromDiscontinuedOperations,
+                "otherAdjustmentsToNetIncome": 0,
+                "netIncomeDeductions": 0,
+                "bottomLineNetIncome": netIncome,
+            }
+        elif statement_type == "balance_sheet":
+            # Assets
+            cashAndCashEquivalents = _get_financial_value(data, "CashAndCashEquivalentsAtCarryingValue")
+            shortTermInvestments = _get_financial_value(data, "MarketableSecuritiesCurrent", alternate_tags=["ShortTermInvestments"])
+            cashAndShortTermInvestments = cashAndCashEquivalents + shortTermInvestments
+
+            netReceivables = _get_financial_value(data, "AccountsReceivableNetCurrent")
+            accountsReceivables = _get_financial_value(data, "AccountsReceivableTradeCurrent")
+            otherReceivables = _get_financial_value(data, "OtherReceivablesCurrent")
+            inventory = _get_financial_value(data, "InventoryNet")
+            prepaids = _get_financial_value(data, "PrepaidExpenseCurrent")
+            otherCurrentAssets = _get_financial_value(data, "OtherAssetsCurrent")
+            totalCurrentAssets = _get_financial_value(data, "AssetsCurrent")
+
+            propertyPlantEquipmentNet = _get_financial_value(data, "PropertyPlantAndEquipmentNet")
+            goodwill = _get_financial_value(data, "Goodwill")
+            intangibleAssets = _get_financial_value(data, "IntangibleAssetsNetExcludingGoodwill")
+            goodwillAndIntangibleAssets = goodwill + intangibleAssets
+            longTermInvestments = _get_financial_value(data, "MarketableSecuritiesNoncurrent", alternate_tags=["LongTermInvestments"])
+            taxAssets = _get_financial_value(data, "DeferredTaxAssetsNet") # This is often net of current/noncurrent or just noncurrent portion
+            otherNonCurrentAssets = _get_financial_value(data, "OtherAssetsNoncurrent")
+            totalNonCurrentAssets = _get_financial_value(data, "AssetsNoncurrent")
+            totalAssets = _get_financial_value(data, "Assets")
+
+            # Liabilities
+            accountPayables = _get_financial_value(data, "AccountsPayableCurrent")
+            otherPayables = _get_financial_value(data, "OtherAccountsPayableCurrent")
+            totalPayables = accountPayables + otherPayables
+            accruedExpenses = _get_financial_value(data, "AccruedLiabilitiesCurrent")
+
+            # Short term debt: Try a total tag first, then sum components if total is zero.
+            shortTermDebt = _get_financial_value(data, "DebtCurrent") # Try overall tag first
+            if shortTermDebt == 0:
+                # Sum of more specific, generally distinct components
+                component_sum = (
+                    _get_financial_value(data, "CommercialPaper") +
+                    _get_financial_value(data, "LongTermDebtCurrentMaturities") +
+                    _get_financial_value(data, "NotesPayableCurrent") +
+                    _get_financial_value(data, "ShortTermBorrowings")
+                )
+                # If the sum of specific components is zero, and the broader tag for
+                # current LTD + other STD exists, use it as a last resort.
+                if component_sum == 0:
+                     alt_std = _get_financial_value(data, "LongTermDebtCurrentMaturitiesAndOtherShortTermDebt")
+                     if alt_std != 0: # Use if it has a value and primary components were all zero
+                         component_sum = alt_std
+                shortTermDebt = component_sum
+
+
+            capitalLeaseObligationsCurrent = _get_financial_value(data, "OperatingLeaseLiabilityCurrent", alternate_tags=["CapitalLeaseObligationsCurrent"])
+            taxPayables = _get_financial_value(data, "IncomeTaxesPayable")
+            deferredRevenue = _get_financial_value(data, "DeferredRevenueCurrent", alternate_tags=["ContractWithCustomerLiabilityCurrent"])
+            otherCurrentLiabilities = _get_financial_value(data, "OtherLiabilitiesCurrent")
+            totalCurrentLiabilities = _get_financial_value(data, "LiabilitiesCurrent")
+
+            longTermDebt_val = _get_financial_value(data, "LongTermDebtNoncurrent")
+            capitalLeaseObligationsNonCurrent = _get_financial_value(data, "OperatingLeaseLiabilityNoncurrent", alternate_tags=["CapitalLeaseObligationsNoncurrent"])
+            deferredRevenueNonCurrent = _get_financial_value(data, "DeferredRevenueNoncurrent", alternate_tags=["ContractWithCustomerLiabilityNoncurrent"])
+            deferredTaxLiabilitiesNonCurrent = _get_financial_value(data, "DeferredTaxLiabilitiesNoncurrent")
+            otherNonCurrentLiabilities = _get_financial_value(data, "OtherLiabilitiesNoncurrent")
+            totalNonCurrentLiabilities = _get_financial_value(data, "LiabilitiesNoncurrent")
+            capitalLeaseObligations = capitalLeaseObligationsCurrent + capitalLeaseObligationsNonCurrent
+
+            totalLiabilities_explicit = _get_financial_value(data, "Liabilities")
+            # If the explicit 'Liabilities' tag is zero or not found,
+            # calculate from components if they exist.
+            if totalLiabilities_explicit != 0:
+                totalLiabilities = totalLiabilities_explicit
+            elif totalCurrentLiabilities != 0 or totalNonCurrentLiabilities != 0:
+                totalLiabilities = totalCurrentLiabilities + totalNonCurrentLiabilities
+            else:
+                totalLiabilities = 0 # Default if neither explicit 'Liabilities' nor components are found
+
+            # Equity
+            treasuryStock = _get_financial_value(data, "TreasuryStockValue")
+            preferredStock = _get_financial_value(data, "PreferredStockValue", alternate_tags=["RedeemablePreferredStockCarryingAmount"])
+            commonStock = _get_financial_value(data, "CommonStockValue", alternate_tags=["CommonStocksIncludingAdditionalPaidInCapital"])
+            additionalPaidInCapital = _get_financial_value(data, "AdditionalPaidInCapital")
+            if commonStock == _get_financial_value(data, "CommonStocksIncludingAdditionalPaidInCapital") and additionalPaidInCapital == 0: # If APIC was part of commonStock tag
+                 commonStock -= additionalPaidInCapital # Try to separate if possible, crude
+                 if commonStock < 0 : commonStock = _get_financial_value(data, "CommonStockValue") # revert if negative
+
+            retainedEarnings = _get_financial_value(data, "RetainedEarningsAccumulatedDeficit")
+            accumulatedOtherComprehensiveIncomeLoss = _get_financial_value(data, "AccumulatedOtherComprehensiveIncomeLossNetOfTax")
+            totalStockholdersEquity = _get_financial_value(data, "StockholdersEquity", alternate_tags=["StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest"])
+            minorityInterest = _get_financial_value(data, "MinorityInterest", alternate_tags=["NoncontrollingInterest"])
+            if minorityInterest == 0 and _get_financial_value(data, "StockholdersEquity") != totalStockholdersEquity: # Infer if main tag included it
+                minorityInterest = totalStockholdersEquity - _get_financial_value(data, "StockholdersEquity")
+
+            totalLiabilitiesAndTotalEquity = totalLiabilities + totalStockholdersEquity
+            totalInvestments = shortTermInvestments + longTermInvestments
+            # Total Debt: financial short-term debt + financial long-term debt + total capital/operating lease obligations
+            totalDebt = shortTermDebt + longTermDebt_val + capitalLeaseObligations
+            netDebt = totalDebt - cashAndCashEquivalents
+
+            item = {
+                **base_item,
+                "cashAndCashEquivalents": cashAndCashEquivalents,
+                "shortTermInvestments": shortTermInvestments,
+                "cashAndShortTermInvestments": cashAndShortTermInvestments,
+                "netReceivables": netReceivables,
+                "accountsReceivables": accountsReceivables, # May need refinement based on company specifics
+                "otherReceivables": otherReceivables, # May need refinement
+                "inventory": inventory,
+                "prepaids": prepaids,
+                "otherCurrentAssets": otherCurrentAssets,
+                "totalCurrentAssets": totalCurrentAssets,
+                "propertyPlantEquipmentNet": propertyPlantEquipmentNet,
+                "goodwill": goodwill,
+                "intangibleAssets": intangibleAssets,
+                "goodwillAndIntangibleAssets": goodwillAndIntangibleAssets,
+                "longTermInvestments": longTermInvestments,
+                "taxAssets": taxAssets,
+                "otherNonCurrentAssets": otherNonCurrentAssets,
+                "totalNonCurrentAssets": totalNonCurrentAssets,
+                "otherAssets": 0, # Default
+                "totalAssets": totalAssets,
+                "totalPayables": totalPayables, # Derived
+                "accountPayables": accountPayables,
+                "otherPayables": otherPayables,
+                "accruedExpenses": accruedExpenses,
+                "shortTermDebt": shortTermDebt,
+                "capitalLeaseObligationsCurrent": capitalLeaseObligationsCurrent,
+                "taxPayables": taxPayables,
+                "deferredRevenue": deferredRevenue,
+                "otherCurrentLiabilities": otherCurrentLiabilities,
+                "totalCurrentLiabilities": totalCurrentLiabilities,
+                "longTermDebt": longTermDebt_val,
+                "capitalLeaseObligationsNonCurrent": capitalLeaseObligationsNonCurrent,
+                "deferredRevenueNonCurrent": deferredRevenueNonCurrent,
+                "deferredTaxLiabilitiesNonCurrent": deferredTaxLiabilitiesNonCurrent,
+                "otherNonCurrentLiabilities": otherNonCurrentLiabilities,
+                "totalNonCurrentLiabilities": totalNonCurrentLiabilities,
+                "otherLiabilities": 0, # Default
+                "capitalLeaseObligations": capitalLeaseObligations, # Derived
+                "totalLiabilities": totalLiabilities,
+                "treasuryStock": treasuryStock,
+                "preferredStock": preferredStock,
+                "commonStock": commonStock,
+                "retainedEarnings": retainedEarnings,
+                "additionalPaidInCapital": additionalPaidInCapital,
+                "accumulatedOtherComprehensiveIncomeLoss": accumulatedOtherComprehensiveIncomeLoss,
+                "otherTotalStockholdersEquity": 0, # Default
+                "totalStockholdersEquity": totalStockholdersEquity,
+                "totalEquity": totalStockholdersEquity,
+                "minorityInterest": minorityInterest,
+                "totalLiabilitiesAndTotalEquity": totalLiabilitiesAndTotalEquity,
+                "totalInvestments": totalInvestments,
+                "totalDebt": totalDebt,
+                "netDebt": netDebt,
+            }
+        elif statement_type == "cash_flow":
+            # Operating Activities
+            netIncome_cf = _get_financial_value(data, "NetIncomeLoss") # Often starting point
+            depreciationAndAmortization_cf = _get_financial_value(data, "DepreciationDepletionAndAmortization")
+            deferredIncomeTax_cf = _get_financial_value(data, "DeferredIncomeTaxExpenseBenefit", alternate_tags=["IncreaseDecreaseInDeferredIncomeTaxes"])
+            stockBasedCompensation_cf = _get_financial_value(data, "ShareBasedCompensation")
+
+            accountsReceivables_flow = _get_financial_value(data, "IncreaseDecreaseInAccountsReceivableNetCurrent")
+            inventory_flow = _get_financial_value(data, "IncreaseDecreaseInInventoriesNet")
+            accountsPayables_flow = _get_financial_value(data, "IncreaseDecreaseInAccountsPayableCurrent")
+            otherWorkingCapital_flow = _get_financial_value(data, "IncreaseDecreaseInOtherOperatingAssetsLiabilitiesNet")
+            changeInWorkingCapital = accountsReceivables_flow + inventory_flow + accountsPayables_flow + otherWorkingCapital_flow # Sum of individual flow components
+
+            otherNonCashItems_cf = _get_financial_value(data, "OtherNoncashIncomeExpense")
+            netCashProvidedByOperatingActivities = _get_financial_value(data, "NetCashProvidedByUsedInOperatingActivities")
+
+            # Investing Activities
+            investmentsInPropertyPlantAndEquipment = _get_financial_value(data, "PaymentsToAcquirePropertyPlantAndEquipment") # Typically negative
+            acquisitionsNet_cf = _get_financial_value(data, "PaymentsToAcquireBusinessesNetOfCashAcquired")
+            purchasesOfInvestments_cf = _get_financial_value(data, "PaymentsForPurchasesOfInvestments")
+            salesMaturitiesOfInvestments_cf = _get_financial_value(data, "ProceedsFromSaleAndMaturityOfMarketableSecurities")
+            otherInvestingActivities_cf = _get_financial_value(data, "OtherInvestingActivitiesCashFlows")
+            netCashProvidedByInvestingActivities = _get_financial_value(data, "NetCashProvidedByUsedInInvestingActivities")
+
+            # Financing Activities
+            proceedsFromLongTermDebt = _get_financial_value(data, "ProceedsFromIssuanceOfLongTermDebt")
+            repaymentsOfLongTermDebt = _get_financial_value(data, "RepaymentsOfLongTermDebt") # Typically negative
+            longTermNetDebtIssuance = proceedsFromLongTermDebt + repaymentsOfLongTermDebt
+
+            proceedsFromShortTermDebt = _get_financial_value(data, "ProceedsFromShortTermDebt")
+            repaymentsOfShortTermDebt = _get_financial_value(data, "RepaymentsOfShortTermDebt") # Typically negative
+            shortTermNetDebtIssuance = proceedsFromShortTermDebt + repaymentsOfShortTermDebt
+
+            netDebtIssuance = longTermNetDebtIssuance + shortTermNetDebtIssuance
+
+            proceedsFromCommonStock = _get_financial_value(data, "ProceedsFromIssuanceOfCommonStock")
+            paymentsForRepurchaseOfCommonStock = _get_financial_value(data, "PaymentsForRepurchaseOfCommonStock") # Typically negative
+            netCommonStockIssuance = proceedsFromCommonStock + paymentsForRepurchaseOfCommonStock
+            commonStockRepurchased_cf = paymentsForRepurchaseOfCommonStock # Matches example's negative convention
+
+            proceedsFromPreferredStock = _get_financial_value(data, "ProceedsFromIssuanceOfPreferredStock")
+            paymentsForRepurchaseOfPreferredStock = _get_financial_value(data, "PaymentsForRepurchaseOfPreferredStock") # Typically negative
+            netPreferredStockIssuance = proceedsFromPreferredStock + paymentsForRepurchaseOfPreferredStock
+
+            netStockIssuance = netCommonStockIssuance + netPreferredStockIssuance
+
+            commonDividendsPaid_cf = _get_financial_value(data, "PaymentsOfDividendsCommonStock") # Typically negative
+            preferredDividendsPaid_cf = _get_financial_value(data, "PaymentsOfDividendsPreferredStock") # Typically negative
+            netDividendsPaid_cf = commonDividendsPaid_cf + preferredDividendsPaid_cf
+
+            otherFinancingActivities_cf = _get_financial_value(data, "OtherFinancingActivitiesCashFlows")
+            netCashProvidedByFinancingActivities = _get_financial_value(data, "NetCashProvidedByUsedInFinancingActivities")
+
+            # Summary
+            effectOfForexChangesOnCash_cf = _get_financial_value(data, "EffectOfExchangeRateOnCashAndCashEquivalents")
+            netChangeInCash = _get_financial_value(data, "CashAndCashEquivalentsPeriodIncreaseDecrease")
+            cashAtEndOfPeriod_cf = _get_financial_value(data, "CashAndCashEquivalentsAtCarryingValue")
+            cashAtBeginningOfPeriod_cf = _get_financial_value(data, "CashCashEquivalentsRestrictedCashAndRestrictedCashEquivalentsAtBeginningOfPeriod", alternate_tags=["CashAndCashEquivalentsAtBeginningOfPeriod"])
+            if cashAtBeginningOfPeriod_cf == 0 and cashAtEndOfPeriod_cf != 0 and netChangeInCash != 0 : # Try to derive if not found
+                cashAtBeginningOfPeriod_cf = cashAtEndOfPeriod_cf - netChangeInCash - effectOfForexChangesOnCash_cf # Adjust for forex too
+
+            # Derived & Other
+            operatingCashFlow_cf = netCashProvidedByOperatingActivities # Alias
+            capitalExpenditure_cf = investmentsInPropertyPlantAndEquipment * -1 if investmentsInPropertyPlantAndEquipment < 0 else investmentsInPropertyPlantAndEquipment # Make positive
+            freeCashFlow_cf = netCashProvidedByOperatingActivities + investmentsInPropertyPlantAndEquipment # Capex is negative
+
+            incomeTaxesPaid_cf = _get_financial_value(data, "IncomeTaxesPaidNet")
+            interestPaid_cf = _get_financial_value(data, "InterestPaidNet")
+
+            item = {
+                **base_item,
+                "netIncome": netIncome_cf,
+                "depreciationAndAmortization": depreciationAndAmortization_cf,
+                "deferredIncomeTax": deferredIncomeTax_cf,
+                "stockBasedCompensation": stockBasedCompensation_cf,
+                "changeInWorkingCapital": changeInWorkingCapital,
+                "accountsReceivables": accountsReceivables_flow, # Note: this is the flow amount
+                "inventory": inventory_flow, # Note: this is the flow amount
+                "accountsPayables": accountsPayables_flow, # Note: this is the flow amount
+                "otherWorkingCapital": otherWorkingCapital_flow,
+                "otherNonCashItems": otherNonCashItems_cf,
+                "netCashProvidedByOperatingActivities": netCashProvidedByOperatingActivities,
+                "investmentsInPropertyPlantAndEquipment": investmentsInPropertyPlantAndEquipment,
+                "acquisitionsNet": acquisitionsNet_cf,
+                "purchasesOfInvestments": purchasesOfInvestments_cf,
+                "salesMaturitiesOfInvestments": salesMaturitiesOfInvestments_cf,
+                "otherInvestingActivities": otherInvestingActivities_cf,
+                "netCashProvidedByInvestingActivities": netCashProvidedByInvestingActivities,
+                "netDebtIssuance": netDebtIssuance,
+                "longTermNetDebtIssuance": longTermNetDebtIssuance,
+                "shortTermNetDebtIssuance": shortTermNetDebtIssuance,
+                "netStockIssuance": netStockIssuance,
+                "netCommonStockIssuance": netCommonStockIssuance,
+                "commonStockIssuance": proceedsFromCommonStock,
+                "commonStockRepurchased": commonStockRepurchased_cf,
+                "netPreferredStockIssuance": netPreferredStockIssuance,
+                "netDividendsPaid": netDividendsPaid_cf,
+                "commonDividendsPaid": commonDividendsPaid_cf,
+                "preferredDividendsPaid": preferredDividendsPaid_cf,
+                "otherFinancingActivities": otherFinancingActivities_cf,
+                "netCashProvidedByFinancingActivities": netCashProvidedByFinancingActivities,
+                "effectOfForexChangesOnCash": effectOfForexChangesOnCash_cf,
+                "netChangeInCash": netChangeInCash,
+                "cashAtEndOfPeriod": cashAtEndOfPeriod_cf,
+                "cashAtBeginningOfPeriod": cashAtBeginningOfPeriod_cf,
+                "operatingCashFlow": operatingCashFlow_cf,
+                "capitalExpenditure": capitalExpenditure_cf,
+                "freeCashFlow": freeCashFlow_cf,
+                "incomeTaxesPaid": incomeTaxesPaid_cf,
+                "interestPaid": interestPaid_cf,
+            }
+        else:
+            item = {**base_item, "error": "Unknown statement type for formatting"}
+        formatted_results.append(item)
+
+    return formatted_results
+
+# Main class to be exposed as the public interface of the package
+class SECHelper:
+    def __init__(self, user_agent_string=None):
+        """
+        Initializes the SECHelper.
+
+        Args:
+            user_agent_string (str, optional): A custom user-agent string for API requests.
+                                            It's highly recommended to provide a descriptive
+                                            user-agent (e.g., "YourAppName/1.0 (your-email@example.com)")
+                                            to identify your application to the SEC.
+                                            If None, a default will be used.
+        """
+        if user_agent_string:
+            self.user_agent = user_agent_string
+        else:
+            # Default User-Agent if none provided
+            self.user_agent = "PythonSECHelper/0.1.0 (contact@example.com)"
+
+        self.headers = {"User-Agent": self.user_agent}
+        print(f"SECHelper initialized. Using User-Agent: {self.user_agent}")
+
+    def _get_cik_map(self):
+        headers_tuple = tuple(sorted(self.headers.items())) # Make headers hashable for the cache key
+        return _fetch_and_cache_cik_map(headers_tuple)
+    def get_cik_for_symbol(self, symbol):
+        """
+        Retrieves the Central Index Key (CIK) for a given stock ticker symbol.
+
+        Args:
+            symbol (str): The stock ticker symbol (e.g., "AAPL").
+
+        Returns:
+            str: The 10-digit CIK as a string, or None if not found.
+        """
+        cik_map = self._get_cik_map()
+        return _get_cik_from_map(symbol, cik_map)
+
+    def get_company_all_facts(self, symbol_or_cik):
+        """
+        Fetches all company facts (XBRL disclosures) for a given company.
+        This provides a comprehensive dataset for a company, including various
+        financial concepts and their reported values over different periods.
+
+        Args:
+            symbol_or_cik (str): The stock ticker symbol (e.g., "AAPL") or
+                                 the 10-digit CIK (e.g., "0000320193").
+
+        Returns:
+            dict: A dictionary containing all company facts in JSON format,
+                  or None if the data cannot be retrieved.
+        """
+        return _get_company_facts_request(symbol_or_cik, self.headers, self.get_cik_for_symbol)
+
+    def get_company_specific_concept(self, symbol_or_cik, taxonomy, tag):
+        """
+        Fetches specific XBRL concept data for a given company.
+
+        Args:
+            symbol_or_cik (str): The stock ticker symbol (e.g., "AAPL") or
+                                 the 10-digit CIK (e.g., "0000320193").
+            taxonomy (str): The XBRL taxonomy (e.g., "us-gaap").
+            tag (str): The XBRL tag/concept (e.g., "Revenues").
+
+        Returns:
+            dict: A dictionary containing the concept data in JSON format,
+                  or None if the data cannot be retrieved.
+        """
+        return _get_company_concept_request(symbol_or_cik, taxonomy, tag, self.headers, self.get_cik_for_symbol)
+
+    def get_aggregated_frames_data(self, taxonomy, tag, unit, year, quarter=None, instantaneous=False):
+        """
+        Fetches aggregated XBRL data across reporting entities for a specific concept
+        and calendrical period. Useful for comparing a single metric across multiple
+        companies or for a specific period (e.g., 'Total Assets' for Q1 2023 across all filers).
+
+        Args:
+            taxonomy (str): The XBRL taxonomy (e.g., "us-gaap").
+            tag (str): The XBRL tag/concept (e.g., "Assets").
+            unit (str): The unit of measure (e.g., "USD", "shares").
+            year (int): The calendar year (e.g., 2023).
+            quarter (int, optional): The quarter (1, 2, 3, or 4). If None, fetches annual data.
+            instantaneous (bool, optional): True for instantaneous data (e.g., balance sheet items),
+                                            False for duration data (e.g., income statement items).
+                                            Defaults to False.
+
+        Returns:
+            dict: A dictionary containing the aggregated frame data in JSON format,
+                  or None if the data cannot be retrieved.
+        """
+        return _get_frames_data_request(taxonomy, tag, unit, year, self.headers, quarter, instantaneous)
+
+    def get_income_statement(self, symbol, limit=5, report_type="ALL"):
+        """
+        Fetches and formats recent income statement data for a given symbol.
+
+        Args:
+            symbol (str): The stock ticker symbol.
+            limit (int): The number of recent periods to retrieve.
+            report_type (str): The type of report to filter by ("10-K", "10-Q", "ALL").
+                               Defaults to "ALL".
+
+        Returns:
+            list: A list of dictionaries with income statement data.
+        """
+        return _get_financial_statement_data(
+            symbol, "income_statement", limit, report_type,
+            self.headers,
+            self.get_cik_for_symbol,
+            self.get_company_all_facts # Pass the instance method
+        )
+
+    def get_balance_sheet(self, symbol, limit=5, report_type="ALL"):
+        """
+        Fetches and formats recent balance sheet data for a given symbol.
+
+        Args:
+            symbol (str): The stock ticker symbol.
+            limit (int): The number of recent periods to retrieve.
+            report_type (str): The type of report to filter by ("10-K", "10-Q", "ALL").
+                               Defaults to "ALL".
+
+        Returns:
+            list: A list of dictionaries with balance sheet data.
+        """
+        return _get_financial_statement_data(
+            symbol, "balance_sheet", limit, report_type,
+            self.headers,
+            self.get_cik_for_symbol,
+            self.get_company_all_facts
+        )
+
+    def get_cash_flow_statement(self, symbol, limit=5, report_type="ALL"):
+        """
+        Fetches and formats recent cash flow statement data for a given symbol.
+
+        Args:
+            symbol (str): The stock ticker symbol.
+            limit (int): The number of recent periods to retrieve.
+            report_type (str): The type of report to filter by ("10-K", "10-Q", "ALL").
+                               Defaults to "ALL".
+
+        Returns:
+            list: A list of dictionaries with cash flow statement data.
+        """
+        return _get_financial_statement_data(
+            symbol, "cash_flow", limit, report_type,
+            self.headers,
+            self.get_cik_for_symbol,
+            self.get_company_all_facts
+        )


### PR DESCRIPTION
Summary
-------

This Python package, sec-financial-data, is designed to simplify the process of retrieving and accessing publicly available financial data from the U.S. Securities and Exchange Commission's (SEC) EDGAR database. It acts as a convenient wrapper around the SEC's EDGAR APIs, providing a more Pythonic and user-friendly interface for developers and financial analysts.


Repro
-----
NA

Automated Testing (Includes Unit Tests)
-----------------
/usr/local/bin/python main.py

Manual Testing
--------------
/usr/local/bin/python main.py

>>> from sec_financial_data.sec_financial_data import SECHelper
>>> helper = SECHelper(user_agent_string="TestApp/1.0 (test@example.com)")
SECHelper initialized. Using User-Agent: TestApp/1.0 (test@example.com)
>>> helper.get_cik_for_symbol("AAPL")
'0000320193'
>>> helper.get_income_statement("AAPL", limit=2, report_type="ALL")
[{'date': '2025-03-29', 'symbol': 'AAPL', 'reportedCurrency': 'USD', 'cik': '0000320193', 'filingDate': '2025-05-02', 'acceptedDate': '2025-05-02', 'fiscalYear': '2025', 'period': 'Q2', 'fiscalDateEnding': '2025-03-29', '_formType_original': '10-Q', 'revenue': 95359000000, 'costOfRevenue': 50492000000, 'grossProfit': 44867000000, 'researchAndDevelopmentExpense': 8550000000, 'generalAndAdministrativeExpenses': 6728000000, 'sellingAndMarketingExpenses': 0, 'otherExpenses': 0, 'operatingExpenses': 15278000000, 'costAndExpenses': 65770000000, 'interestIncome': 0, 'interestExpense': 0, 'depreciationAndAmortization': 5741000000, 'ebitda': 35330000000, 'operatingIncome': 29589000000, 'totalOtherIncomeExpensesNet': 0, 'incomeBeforeTax': 29589000000, 'incomeTaxExpense': 4530000000, 'netIncome': 24780000000, 'eps': 1.65, 'epsDiluted': 1.65, 'weightedAverageShsOut': 14994082000, 'weightedAverageShsOutDil': 15056133000, 'ebit': 29589000000, 'netIncomeFromContinuingOperations': 24780000000, 'netIncomeFromDiscontinuedOperations': 0, 'otherAdjustmentsToNetIncome': 0, 'netIncomeDeductions': 0, 'bottomLineNetIncome': 24780000000}, {'date': '2024-12-28', 'symbol': 'AAPL', 'reportedCurrency': 'USD', 'cik': '0000320193', 'filingDate': '2025-01-31', 'acceptedDate': '2025-01-31', 'fiscalYear': '2025', 'period': 'Q1', 'fiscalDateEnding': '2024-12-28', '_formType_original': '10-Q', 'revenue': 124300000000, 'costOfRevenue': 66025000000, 'grossProfit': 58275000000, 'researchAndDevelopmentExpense': 8268000000, 'generalAndAdministrativeExpenses': 7175000000, 'sellingAndMarketingExpenses': 0, 'otherExpenses': 0, 'operatingExpenses': 15443000000, 'costAndExpenses': 81468000000, 'interestIncome': 0, 'interestExpense': 0, 'depreciationAndAmortization': 3080000000, 'ebitda': 45912000000, 'operatingIncome': 42832000000, 'totalOtherIncomeExpensesNet': 0, 'incomeBeforeTax': 42832000000, 'incomeTaxExpense': 6254000000, 'netIncome': 36330000000, 'eps': 2.41, 'epsDiluted': 2.4, 'weightedAverageShsOut': 15081724000, 'weightedAverageShsOutDil': 15150865000, 'ebit': 42832000000, 'netIncomeFromContinuingOperations': 36330000000, 'netIncomeFromDiscontinuedOperations': 0, 'otherAdjustmentsToNetIncome': 0, 'netIncomeDeductions': 0, 'bottomLineNetIncome': 36330000000}]
>>> 


