### PR TITLE
Deduplicate the annual reports which were filed as ammendments

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,13 +3,14 @@
 from sec_financial_data.sec_financial_data import SECHelper
 import json
 
+
 def main():
     # Initialize the helper. It's highly recommended to provide a descriptive user-agent.
     # Replace "YourAppName/1.0" with your application name and "your-email@example.com"
     # with a contact email for responsible usage as per SEC guidelines.
     helper = SECHelper(user_agent_string="sec_api/0.1.0 (arun.mittal.sjsu@gmail.com)")
 
-    symbol = "AAPL" # Example: Apple Inc.
+    symbol = "AAPL"  # Example: Apple Inc.
 
     print(f"\n--- Getting CIK for {symbol} ---")
     cik = helper.get_cik_for_symbol(symbol)
@@ -17,11 +18,13 @@ def main():
         print(f"CIK for {symbol}: {cik}")
     else:
         print(f"Could not find CIK for {symbol}")
-        return # Exit if CIK not found
+        return  # Exit if CIK not found
 
     # --- Income Statement 10-K Only ---
     print(f"\n--- Getting Income Statement for {symbol} (10-K, limit 5) ---")
-    income_statement_10k = helper.get_income_statement(symbol, limit=5, report_type="10-K")
+    income_statement_10k = helper.get_income_statement(
+        symbol, limit=5, report_type="10-K"
+    )
     if income_statement_10k:
         print(f"Found {len(income_statement_10k)} 10-K reports.")
         print(json.dumps(income_statement_10k, indent=2))
@@ -48,7 +51,9 @@ def main():
 
     # --- Income Statement 10-Q Only ---
     print(f"\n--- Getting Income Statement for {symbol} (10-Q, limit 1) ---")
-    income_statement_10q = helper.get_income_statement(symbol, limit=1, report_type="10-Q")
+    income_statement_10q = helper.get_income_statement(
+        symbol, limit=1, report_type="10-Q"
+    )
     if income_statement_10q:
         print(f"Found {len(income_statement_10q)} 10-Q reports.")
         print(json.dumps(income_statement_10q, indent=2))
@@ -75,7 +80,9 @@ def main():
 
     # --- Advanced Usage: Fetching specific XBRL concepts ---
     print(f"\n--- Getting specific concept: 'Revenues' for {symbol} ---")
-    revenues_concept = helper.get_company_specific_concept(symbol, "us-gaap", "Revenues")
+    revenues_concept = helper.get_company_specific_concept(
+        symbol, "us-gaap", "Revenues"
+    )
     if revenues_concept:
         # This will contain raw XBRL facts. You'd typically process this further.
         # For demonstration, we'll just print a small part of it.
@@ -83,10 +90,12 @@ def main():
         print(f"Description: {revenues_concept.get('description')}")
 
         # Example of accessing some facts (first 2 for brevity)
-        if 'units' in revenues_concept and 'USD' in revenues_concept['units']:
+        if "units" in revenues_concept and "USD" in revenues_concept["units"]:
             print("First 2 USD facts for Revenues:")
-            for fact in revenues_concept['units']['USD'][:2]:
-                print(f"  Value: {fact.get('val')}, Fiscal Year: {fact.get('fy')}, Period: {fact.get('fp')}, End Date: {fact.get('end')}")
+            for fact in revenues_concept["units"]["USD"][:2]:
+                print(
+                    f"  Value: {fact.get('val')}, Fiscal Year: {fact.get('fy')}, Period: {fact.get('fp')}, End Date: {fact.get('end')}"
+                )
         else:
             print("No USD facts found for Revenues.")
     else:
@@ -102,26 +111,34 @@ def main():
     assets_q1_frames = helper.get_aggregated_frames_data(
         "us-gaap", "Assets", "USD", year_for_frames, quarter=1, instantaneous=True
     )
-    if assets_q1_frames and 'data' in assets_q1_frames: # The 'frames' API returns data under a 'data' key
-        print(f"Total number of companies reporting Assets in Q1 {year_for_frames}: {len(assets_q1_frames['data'])}")
-        if assets_q1_frames['data']:
+    if (
+        assets_q1_frames and "data" in assets_q1_frames
+    ):  # The 'frames' API returns data under a 'data' key
+        print(
+            f"Total number of companies reporting Assets in Q1 {year_for_frames}: {len(assets_q1_frames['data'])}"
+        )
+        if assets_q1_frames["data"]:
             print(f"Label for aggregated data: {assets_q1_frames.get('label', 'N/A')}")
-            print(f"Description for aggregated data: {assets_q1_frames.get('description', 'N/A')}")
+            print(
+                f"Description for aggregated data: {assets_q1_frames.get('description', 'N/A')}"
+            )
             print("Sample of Assets data (first 3 companies):")
-            for i, item in enumerate(assets_q1_frames['data'][:3]):
+            for i, item in enumerate(assets_q1_frames["data"][:3]):
                 # The 'frames' API returns CIKs directly
-                sample_cik = item.get('cik')
-                sample_entity_name = item.get('entityName', 'N/A')
-                sample_value = item.get('val')
-                sample_accn = item.get('accn') # Accession number of the filing
-                sample_form = item.get('form') # Form type (e.g., 10-K, 10-Q)
-                sample_end = item.get('end')   # End date of the reported fact
+                sample_cik = item.get("cik")
+                sample_entity_name = item.get("entityName", "N/A")
+                sample_value = item.get("val")
+                sample_accn = item.get("accn")  # Accession number of the filing
+                sample_form = item.get("form")  # Form type (e.g., 10-K, 10-Q)
+                sample_end = item.get("end")  # End date of the reported fact
                 print(
                     f"  Company CIK: {sample_cik}, Name: {sample_entity_name}, "
                     f"Value: {sample_value}, Form: {sample_form}, End Date: {sample_end}, Accn: {sample_accn}"
                 )
         else:
-            print(f"No company data found within the aggregated Assets data for Q1 {year_for_frames}.")
+            print(
+                f"No company data found within the aggregated Assets data for Q1 {year_for_frames}."
+            )
     else:
         print(f"No aggregated Assets data found for Q1 {year_for_frames}.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sec-financial-data" # Choose a unique name for PyPI
-version = "0.1.1"
+version = "0.1.2"
 authors = [
   { name="Arun Mittal", email="arun.mittal.sjsu@gmail.com" },
 ]


### PR DESCRIPTION
Summary
-------

The previous logic for deduplicating financial statement reports (e.g., 10-Ks) could result in multiple records for the same calendar year, especially for companies with non-standard fiscal years, amendments, or multiple filings in a year. Additionally, the latest report for a year could have missing (zero) values for some fields, leading to incomplete data.

The new approach ensures that for each calendar year, only one 10-K report is returned, and all numeric fields are as complete as possible:

1. Grouping: All 10-K reports are grouped by the calendar year (extracted from endDate).
2. Selection: For each year, the report with the latest endDate is selected as the base.
3. Patching: For every numeric field in the base report, if the value is zero, the code looks back through earlier reports for that year and fills in the first non-zero value found.
4. Result: Only one patched, most complete 10-K report is returned per year.

Minor formatting improvements were made to the example script, but the main change is in the backend logic for fetching and displaying financial statements.

Repro
-----
NA

Automated Testing (Includes Unit Tests)
-----------------


Manual Testing
--------------
Create following test script to test

`from sec_financial_data.sec_financial_data import SECHelper

if __name__ == "__main__":
    # Initialize the helper with a descriptive user agent (recommended by SEC)
    sec_helper = SECHelper("TestScript/1.0 (your-email@example.com)")
    # Fetch the last 10 years of income statements for CNC (Centene Corporation)
    results = sec_helper.get_income_statement("CNC", limit=10, report_type="10-K")
    for idx, report in enumerate(results, 1):
        print(f"\n--- Report {idx} ---")
        for k, v in report.items():
            print(f"{k}: {v}")`

